### PR TITLE
Refactor table detection and rendering logic with improved regex

### DIFF
--- a/utils/handlers/messages.py
+++ b/utils/handlers/messages.py
@@ -128,30 +128,52 @@ class MessageSender:
         Returns: (last_message, list_of_table_data)
         """
         response, table_images, table_data = detect_and_convert_tables(response)
-        pattern = re.compile(f"({TABLE_IMAGE_PLACEHOLDER}_\\d+)|(```[\\s\\S]*?```)")
+        
+        # Log for debugging
+        logger.debug(f"Process and send: {len(table_images)} tables detected")
+        
+        # Escape placeholder for regex safely
+        placeholder_escaped = re.escape(TABLE_IMAGE_PLACEHOLDER)
+        pattern = re.compile(f"({placeholder_escaped}_\\d+__)|(```[\\s\\S]*?```)")
+        
+        # Split by placeholders or code blocks
         parts = pattern.split(response)
-        parts = [p for p in parts if p is not None and (p.strip() or p.startswith(TABLE_IMAGE_PLACEHOLDER))]
+        
+        # Filter None and preserve empty strings that might be whitespace between parts
+        parts = [p for p in parts if p is not None]
         
         target = self._get_target_channel()
         last_message = None
 
         for part in parts:
-            if part.startswith(TABLE_IMAGE_PLACEHOLDER):
+            if not part:
+                continue
+                
+            if part.startswith(TABLE_IMAGE_PLACEHOLDER) and part.endswith("__"):
                 try:
-                    idx = int(part.split("_")[-1])
-                    img_buffer = table_images[idx]
-                    current_table_data = table_data[idx]
-                    
-                    img_buffer.seek(0)
-                    file = discord.File(fp=img_buffer, filename="table.png")
-                    
-                    from utils.views.message import TableActionView
-                    view = TableActionView(current_table_data)
-                    last_message = await target.send(file=file, view=view)
-                except (IndexError, ValueError) as e:
-                    logger.error(f"Failed to send table message with view: {e}")
+                    idx_str = part[len(TABLE_IMAGE_PLACEHOLDER)+1:-2]
+                    idx = int(idx_str)
+                    if idx < len(table_images):
+                        logger.debug(f"Sending table image for index {idx}")
+                        img_buffer = table_images[idx]
+                        current_table_data = table_data[idx]
+                        
+                        img_buffer.seek(0)
+                        file = discord.File(fp=img_buffer, filename=f"table_{idx}.png")
+                        
+                        from utils.views.message import TableActionView
+                        view = TableActionView(current_table_data)
+                        last_message = await target.send(file=file, view=view)
+                    else:
+                        logger.error(f"Table index {idx} out of range (total images: {len(table_images)})")
+                        last_message = await self.send_text_with_latex(part)
+                except Exception as e:
+                    logger.error(f"Failed to send table message: {e}")
+                    last_message = await self.send_text_with_latex(part)
             elif part.startswith("```") and part.endswith("```"):
-                last_message = await send_code_block_with_return(target, part, self.max_length, bot=self.bot)
+                # If it's a code block but NOT a table placeholder (since we already extracted them)
+                if TABLE_IMAGE_PLACEHOLDER not in part:
+                    last_message = await send_code_block_with_return(target, part, self.max_length, bot=self.bot)
             else:
                 last_message = await self.send_text_with_latex(part)
 

--- a/utils/handlers/table.py
+++ b/utils/handlers/table.py
@@ -288,73 +288,83 @@ def _render_table_image(headers: List[str], rows: List[List[str]], alignments: L
 
 
 
-TABLE_IMAGE_PLACEHOLDER = "TABLE_IMAGE_RENDERED_PLACEHOLDER"
+TABLE_IMAGE_PLACEHOLDER = "__TABLE_IMG"
 
 def detect_and_convert_tables(text: str) -> tuple[str, list[io.BytesIO], list[dict]]:
     """Detect Markdown tables and render them as images with alignment support.
     Returns: (modified_text, list_of_images, list_of_table_data)
     """
     try:
-        # Pre-process: detect and isolate markdown code blocks containing tables
-        code_block_pattern = re.compile(r"```(?:markdown)?\n((?:\|.*\|(?:\n|$))+)```", re.MULTILINE)
-        
         table_images = []
         table_data_list = []
         
+        # Pre-process: detect and isolate markdown code blocks containing tables
+        # Improved pattern to be more flexible with table headers and separators
+        code_block_pattern = re.compile(r"```(markdown|md)?\n((?:\|.*\|(?:\n|$))+)```", re.MULTILINE)
+        
         def replace_table_block(match):
             logger.debug("Detected markdown table inside code block")
-            table_content = match.group(1).strip()
+            table_content = match.group(2).strip()
             lines = table_content.split("\n")
             headers, rows, alignments = [], [], []
             
-            i = 0
-            while i < len(lines):
-                line = lines[i].strip()
-                if not line.startswith("|") or not line.endswith("|"):
-                    i += 1
-                    continue
-                
-                parts = [p.strip() for p in line[1:-1].split("|")]
-                
-                # Check for separator line
-                if all(re.match(r"^[\s\-\:]+$", p) for p in parts) and parts:
-                    for p in parts:
+            # Filter empty lines
+            lines = [l for l in lines if l.strip()]
+            
+            if not lines:
+                return match.group(0)
+
+            # First line is header
+            headers = [p.strip() for p in lines[0].strip()[1:-1].split("|")]
+            num_cols = len(headers)
+            
+            # Check second line for separator/alignments
+            start_row = 1
+            if len(lines) > 1:
+                sep_parts = [p.strip() for p in lines[1].strip()[1:-1].split("|")]
+                if all(re.match(r"^[\s\-\:]+$", p) for p in sep_parts) and sep_parts:
+                    for p in sep_parts:
                         if p.startswith(":") and p.endswith(":"): alignments.append("center")
                         elif p.endswith(":"): alignments.append("right")
                         else: alignments.append("left")
-                elif not headers:
-                    headers = parts
-                else:
-                    rows.append(parts)
-                i += 1
+                    start_row = 2
+            
+            while len(alignments) < num_cols: alignments.append("left")
+            alignments = alignments[:num_cols]
+            
+            # Rest are rows
+            for i in range(start_row, len(lines)):
+                row_raw = lines[i].strip()
+                if not row_raw: continue
                 
-            if headers and rows:
-                num_cols = len(headers)
-                while len(alignments) < num_cols: alignments.append("left")
-                alignments = alignments[:num_cols]
+                row_split = row_raw.split("|")
+                # Remove first and last empty elements if they exist (standard markdown table)
+                if row_raw.startswith("|"): row_split = row_split[1:]
+                if row_raw.endswith("|"): row_split = row_split[:-1]
                 
-                # Normalize rows
-                normalized_rows = []
-                for r in rows:
-                    if len(r) < num_cols:
-                        r.extend([""] * (num_cols - len(r)))
-                    normalized_rows.append(r[:num_cols])
+                row_parts = [p.strip() for p in row_split]
+                # Pad/truncate row
+                if len(row_parts) < num_cols:
+                    row_parts.extend([""] * (num_cols - len(row_parts)))
+                rows.append(row_parts[:num_cols])
                 
+            if headers:
                 try:
-                    img_buffer, links = _render_table_image(headers, normalized_rows, alignments)
+                    img_buffer, links = _render_table_image(headers, rows, alignments)
                     table_images.append(img_buffer)
                     table_data_list.append({
                         "id": len(table_images) - 1,
                         "headers": headers,
-                        "rows": normalized_rows,
+                        "rows": rows,
                         "links": links
                     })
-                    return f"\n{TABLE_IMAGE_PLACEHOLDER}_{len(table_images)-1}\n"
+                    return f"{TABLE_IMAGE_PLACEHOLDER}_{len(table_images)-1}__"
                 except Exception as e:
                     logger.error(f"Table render failed: {e}")
                     return match.group(0)
             return match.group(0)
 
+        # First pass: replace tables in code blocks with a safer placeholder
         text = code_block_pattern.sub(replace_table_block, text)
 
         # Legacy direct table detection (for tables not in code blocks)
@@ -381,11 +391,13 @@ def detect_and_convert_tables(text: str) -> tuple[str, list[io.BytesIO], list[di
                     i += 1
                 
                 if len(potential_table) >= 2:
-                    headers = [c.strip() for c in potential_table[0].strip()[1:-1].split("|")]
+                    headers_raw = potential_table[0].strip()
+                    headers = [c.strip() for c in headers_raw[1:-1].split("|")]
                     num_cols = len(headers)
                     rows = []
                     for row_str in potential_table[1:]:
-                        cells = [c.strip() for c in row_str.strip()[1:-1].split("|")]
+                        row_raw = row_str.strip()
+                        cells = [c.strip() for c in row_raw[1:-1].split("|")]
                         # Pad or truncate row to match header column count
                         if len(cells) < num_cols:
                             cells.extend([""] * (num_cols - len(cells)))
@@ -394,8 +406,7 @@ def detect_and_convert_tables(text: str) -> tuple[str, list[io.BytesIO], list[di
                         rows.append(cells)
                     
                     while len(alignments) < num_cols: alignments.append("left")
-                    if len(alignments) > num_cols:
-                        alignments = alignments[:num_cols]
+                    alignments = alignments[:num_cols]
                     
                     try:
                         img_buffer, links = _render_table_image(headers, rows, alignments)
@@ -406,7 +417,7 @@ def detect_and_convert_tables(text: str) -> tuple[str, list[io.BytesIO], list[di
                             "rows": rows,
                             "links": links
                         })
-                        output_lines.append(f"\n{TABLE_IMAGE_PLACEHOLDER}_{len(table_images)-1}\n")
+                        output_lines.append(f"{TABLE_IMAGE_PLACEHOLDER}_{len(table_images)-1}__")
                     except Exception as e:
                         logger.error(f"Table render failed: {e}")
                         output_lines.extend(potential_table)


### PR DESCRIPTION
This pull request improves the detection, conversion, and processing of Markdown tables into images within messages, focusing on increased robustness, clearer placeholder handling, and better error logging. The changes affect both the table detection logic and the message sending workflow, ensuring more reliable extraction and rendering of tables, and safer handling of placeholders in the message pipeline.

**Table detection and rendering improvements:**

* Enhanced the Markdown table detection regex to better identify tables inside code blocks, supporting both `markdown` and `md` languages, and improved parsing logic for headers, alignments, and rows.
* Changed the placeholder for rendered table images to `__TABLE_IMG_{index}__` for safer and more consistent matching and splitting. [[1]](diffhunk://#diff-94c33c7c962a18a7a58e35819bcc004bafe4226834c4c790b1ecee6717bd1847L291-R367) [[2]](diffhunk://#diff-94c33c7c962a18a7a58e35819bcc004bafe4226834c4c790b1ecee6717bd1847L409-R420)

**Message processing and placeholder handling:**

* Updated the message processing logic to safely escape the placeholder in regex, correctly split messages by placeholders or code blocks, and handle empty or whitespace-only parts. Improved error handling and logging for out-of-range indices and failures when sending table images.
* Adjusted logic to ensure only valid table placeholders trigger image sending, and code blocks are handled separately from table placeholders.

**Code quality and robustness:**

* Improved error logging and exception handling throughout table detection and message sending, making debugging easier and preventing silent failures. [[1]](diffhunk://#diff-35c9c9cce8a4af7e9c22909ecc763511b6a5d3e844d86c166fef17c53c079e28L131-R175) [[2]](diffhunk://#diff-94c33c7c962a18a7a58e35819bcc004bafe4226834c4c790b1ecee6717bd1847L291-R367)
* Refactored row and alignment normalization for more consistent output, and ensured output placeholders are formatted without extra newlines. [[1]](diffhunk://#diff-94c33c7c962a18a7a58e35819bcc004bafe4226834c4c790b1ecee6717bd1847L384-R400) [[2]](diffhunk://#diff-94c33c7c962a18a7a58e35819bcc004bafe4226834c4c790b1ecee6717bd1847L397) [[3]](diffhunk://#diff-94c33c7c962a18a7a58e35819bcc004bafe4226834c4c790b1ecee6717bd1847L409-R420)