### PR TITLE
refactor: Add SFTP deployment workflow for AlphaLLM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy AlphaLLM via SFTP
+
+on:
+    # Trigger manually from the Actions tab
+    workflow_dispatch: # Trigger on push to main branch
+
+    push:
+        branches:
+            - prod
+
+jobs:
+    deploy:
+        name: SFTP Upload
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: SFTP uploader
+              uses: wangyucode/sftp-upload-action@v3
+              with:
+                  host: ${{ secrets.SFTP_HOST }}
+                  port: ${{ secrets.SFTP_PORT}}
+                  username: ${{ secrets.SFTP_USERNAME }}
+                  password: ${{ secrets.SFTP_PASSWORD }}
+                  localDir: "."
+                  remoteDir: "/"
+                  exclude: ".github,.agents,__pycache__,*.pyc,*-sample,*.service,.flake8,LICENSE,\
+                      README.md,*.sh"
+                  concurrency: 10
+                  forceUpload: false


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate deployment of the AlphaLLM project via SFTP. The workflow is configured to trigger on pushes to the `prod` branch or manually through the Actions tab, and securely uploads the project files to a remote server using SFTP credentials stored in secrets.

**Deployment automation:**

* Added `.github/workflows/deploy.yml` to define a GitHub Actions workflow for deploying AlphaLLM via SFTP, including steps for code checkout and SFTP upload with configurable exclusions and concurrency.